### PR TITLE
Tweaks to summary.tt and detail.tt

### DIFF
--- a/lib/BinningReports/details.tt
+++ b/lib/BinningReports/details.tt
@@ -1,6 +1,6 @@
 <h1>Results for [% g.genome_id %]</h1>
 
-<p><a href="https://docs.patricbrc.org//tutorial/genome_quality_report/genome_quality_report">Tutorial for this page.</a></p>
+<p><a href="https://docs.patricbrc.org/tutorial/genome_quality_report/genome_quality_report.html">Tutorial for this page.</a></p>
 
 <table class="p3basic">
 <tr>

--- a/lib/BinningReports/details.tt
+++ b/lib/BinningReports/details.tt
@@ -1,6 +1,6 @@
 <h1>Results for [% g.genome_id %]</h1>
 
-<p><a href="https://docs.patricbrc.org//tutorial/metagenomic_binning/metagenomic_output.html#the-genome-report">Tutorial for this page.</a></p>
+<p><a href="https://docs.patricbrc.org//tutorial/genome_quality_report/genome_quality_report">Tutorial for this page.</a></p>
 
 <table class="p3basic">
 <tr>

--- a/lib/BinningReports/summary.tt
+++ b/lib/BinningReports/summary.tt
@@ -1,3 +1,24 @@
+<style type="text/css">
+div.body {
+    font-family: Arial, sans-serif;
+    color: #333333;
+    font-weight: 200;
+    font-size: small;
+    background: #FCFCFC;
+}
+table.p3basic, table.p3basic th,
+table.p3basic td, table.p3basic tr {
+    border-style: inset;
+    border-collapse: collapse;
+    vertical-align: top;
+    padding: 3px;
+}
+table.p3basic th {
+    text-align: left;
+    background: #EEEEEE;
+}
+</style>
+<div class="body">
 [% IF job_id %]
 <h1>Metagenomics Binning Report for [% job_id %]</h1>
 
@@ -94,7 +115,7 @@ The following bins did not meet the quality criteria:</p>
 
 [% BLOCK qual_row %]
 <tr>
-<td><a href="[% g.report_url %]">[% g.qscore %]</a></td>
+<td><a target="_parent" href="[% g.report_url %]">[% g.qscore %]</a></td>
 <td><a target="_blank" href="[% g.genome_url %]">[% g.genome_id %]</a></td>
 <td>[% g.genome_name %]</td>
 <td>
@@ -116,3 +137,4 @@ The following bins did not meet the quality criteria:</p>
 <td [% g.seed_color %]>[% g.good_seed %]</td>
 </tr>
 [% END %]
+</div>

--- a/lib/BinningReports/summary.tt
+++ b/lib/BinningReports/summary.tt
@@ -22,7 +22,7 @@ table.p3basic th {
 [% IF job_id %]
 <h1>Metagenomics Binning Report for [% job_id %]</h1>
 
-<p><a href="https://docs.patricbrc.org//tutorial/metagenomic_binning/metagenomic_output.html#the-binning-output-directory">Tutorial for this page.</a></p>
+<p><a href="https://docs.patricbrc.org/tutorial/metagenomic_binning/metagenomic_output.html#the-binning-output-directory">Tutorial for this page.</a></p>
 
 <h2>Input data</h2>
 <p>[% IF params.contigs %]

--- a/lib/GEO.pm
+++ b/lib/GEO.pm
@@ -917,6 +917,20 @@ sub qscore {
     return $retVal;
 }
 
+=head3 quality
+
+    my $quality = $geo->quality;
+
+Return the hash containing the genome's quality analysis data. If the genome has not been evaluated, this will return C<undef>.
+
+=cut
+
+sub quality {
+    my ($self) = @_;
+    return $self->{quality};
+}
+
+
 =head3 metrics
 
     my $metricsH = $geo->metrics;

--- a/scripts/p3x-eval-genomes.pl
+++ b/scripts/p3x-eval-genomes.pl
@@ -404,7 +404,7 @@ eval {
         my %urlMap = map { $_->id => ($_->id . ".html") } @summary;
         open(my $oh, ">$outDir/index.html") || die "Could not open summary web page: $!";
         my $html = BinningReports::Summary('', {}, undef, $summaryTFile, '', \@summary, \%urlMap);
-        print $oh $prefix . "<title>Genome Evaluations</title></head><body>\n" . $html . $suffix;
+        print $oh "<html><head><title>Genome Evaluations</title></head><body>\n" . $html . $suffix;
         close $oh;
     }
 };


### PR DESCRIPTION
The summary page will look better, and both will point to the new tutorial pages.

The other changes are (1) p3-gto will now pull down taxonomic lineage data, improving the evaluator performance on GTOs. (2) Updating the evaluators to be aware that the styles are now embedded in the summary template instead of being separate.